### PR TITLE
Switch to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
   - TOXENV=py26-sqlite
   - TOXENV=py27-sqlite
   - TOXENV=py34-sqlite
-  - TOXENV=py27-pyflakes
-  - TOXENV=py34-pyflakes
+  - TOXENV=py27-flake8
+  - TOXENV=py34-flake8
 
 install: pip install tox
 
@@ -17,7 +17,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: TOXENV=py34-sqlite
-    - env: TOXENV=py27-pyflakes
-    - env: TOXENV=py34-pyflakes
+    - env: TOXENV=py27-flake8
+    - env: TOXENV=py34-flake8
 
 script: tox -e ${TOXENV}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27}-mysql,{py26,py27}-postgres,{py26,py27,py34}-sqlite,{py27,py34}-pyflakes
+envlist = {py26,py27}-mysql,{py26,py27}-postgres,{py26,py27,py34}-sqlite,{py27,py34}-flake8
 
 # Base test environment settings
 [testenv]
@@ -60,12 +60,14 @@ commands =
 commands =
     py.test -D sqlite:///tmp/sqlobject_test.sqdb
 
-[testenv:py27-pyflakes]
+[testenv:py27-flake8]
 deps =
-    pyflakes
-commands = pyflakes .
+    flake8
+changedir =
+commands = flake8 sqlobject/
 
-[testenv:py34-pyflakes]
+[testenv:py34-flake8]
 deps =
-    pyflakes
-commands = pyflakes .
+    flake8
+changedir =
+commands = flake8 sqlobject/


### PR DESCRIPTION
So this uncovers some issues in the tests. In [this build](https://travis-ci.org/sqlobject/sqlobject/builds/44712518) we use a `PYTHONHASHSEED` that causes tests that [depend on dictionary ordering](https://travis-ci.org/sqlobject/sqlobject/jobs/44712519#L218) to fail. So we can set a hashseed value that we know will succeed, but that will only delay the problem. As soon as our tests are able to run on python 3 this will happen regardless of the value of an environment value.

I've also added the pyflakes jobs as allowed failures. There are a lot of lint-related output and we should judiciously fix them. I would have used `flake8` but that also runs `pep8` over the source which I'm unsure we wish to follow. Let me know what you all think.
