### PR TITLE
Issue #3: Use relative imports

### DIFF
--- a/sqlobject/__init__.py
+++ b/sqlobject/__init__.py
@@ -3,13 +3,13 @@
 # Do import for namespace
 # noqa is a directive for flake8 to ignore seemingly unused imports
 
-from __version__ import version, version_info  # noqa
+from .__version__ import version, version_info  # noqa
 
-from col import *  # noqa
-from index import *  # noqa
-from joins import *  # noqa
-from main import *  # noqa
-from sqlbuilder import AND, OR, NOT, IN, LIKE, RLIKE, DESC, CONTAINSSTRING, const, func  # noqa
-from styles import *  # noqa
-from dbconnection import connectionForURI  # noqa
-import dberrors  # noqa
+from .col import *  # noqa
+from .index import *  # noqa
+from .joins import *  # noqa
+from .main import *  # noqa
+from .sqlbuilder import AND, OR, NOT, IN, LIKE, RLIKE, DESC, CONTAINSSTRING, const, func  # noqa
+from .styles import *  # noqa
+from .dbconnection import connectionForURI  # noqa
+from . import dberrors  # noqa

--- a/sqlobject/boundattributes.py
+++ b/sqlobject/boundattributes.py
@@ -26,8 +26,8 @@ attributes.
 __all__ = ['BoundAttribute', 'BoundFactory', 'bind_attributes',
            'bind_attributes_local']
 
-import declarative
-import events
+from . import declarative
+from . import events
 
 
 class BoundAttribute(declarative.Declarative):

--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -1779,7 +1779,8 @@ def pushKey(kw, name, value):
         kw[name] = value
 
 all = []
-for key, value in globals().items():
+# Use copy() to avoid 'dictionary changed' issues on python 3
+for key, value in globals().copy().items():
     if isinstance(value, type) and (issubclass(value, (Col, SOCol))):
         all.append(key)
 __all__.extend(all)

--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -27,12 +27,12 @@ except ImportError:
     import pickle
 import weakref
 from formencode import compound, validators
-from classregistry import findClass
+from .classregistry import findClass
 # Sadly the name "constraints" conflicts with many of the function
 # arguments in this module, so we rename it:
-import constraints as constrs
-import sqlbuilder
-from styles import capword
+from . import constraints as constrs
+from . import sqlbuilder
+from .styles import capword
 
 NoDefault = sqlbuilder.NoDefault
 

--- a/sqlobject/converters.py
+++ b/sqlobject/converters.py
@@ -2,7 +2,15 @@ from array import array
 import datetime
 from decimal import Decimal
 import time
-from types import ClassType, InstanceType, NoneType
+import sys
+if sys.version_info[0] < 3:
+    from types import ClassType, InstanceType, NoneType
+else:
+    # Use suitable aliases for now
+    ClassType = type
+    NoneType = type(None)
+    # This is may not be what we want in all cases, but will do for now
+    InstanceType = object
 
 
 try:
@@ -80,9 +88,13 @@ def StringLikeConverter(value, db):
     return "'%s'" % value
 
 registerConverter(str, StringLikeConverter)
-registerConverter(unicode, StringLikeConverter)
+if sys.version_info[0] < 3:
+    registerConverter(unicode, StringLikeConverter)
 registerConverter(array, StringLikeConverter)
-registerConverter(buffer, StringLikeConverter)
+if sys.version_info[0] < 3:
+    registerConverter(buffer, StringLikeConverter)
+else:
+    registerConverter(memoryview, StringLikeConverter)
 
 
 def IntConverter(value, db):
@@ -94,7 +106,8 @@ registerConverter(int, IntConverter)
 def LongConverter(value, db):
     return str(value)
 
-registerConverter(long, LongConverter)
+if sys.version_info[0] < 3:
+    registerConverter(long, LongConverter)
 
 if NumericType:
     registerConverter(NumericType, IntConverter)

--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -1,7 +1,11 @@
 import atexit
 from cgi import parse_qsl
 import inspect
-import new
+import sys
+if sys.version_info[0] < 3:
+    # Temporary workaround - will need more attention to fix
+    # usage of new in the code
+    import new
 import os
 import threading
 import types

--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -3,20 +3,19 @@ from cgi import parse_qsl
 import inspect
 import new
 import os
-import sys
 import threading
 import types
 import urllib
 import warnings
 import weakref
 
-from cache import CacheSet
-import classregistry
-import col
-from converters import sqlrepr
+from .cache import CacheSet
+from . import classregistry
+from . import col
+from .converters import sqlrepr
 import main
-import sqlbuilder
-from util.threadinglocal import local as threading_local
+from . import sqlbuilder
+from .util.threadinglocal import local as threading_local
 
 warnings.filterwarnings("ignore", "DB-API extension cursor.lastrowid used")
 
@@ -335,7 +334,6 @@ class DBAPI(DBConnection):
 
     ``queryInsertID`` must also be defined.
     """
-
     dbName = None
 
     def __init__(self, **kw):
@@ -1086,11 +1084,11 @@ dbConnectionForScheme = TheURIOpener.dbConnectionForScheme
 
 # Register DB URI schemas -- do import for side effects
 # noqa is a directive for flake8 to ignore seemingly unused imports
-import firebird  # noqa
-import maxdb  # noqa
-import mssql  # noqa
-import mysql  # noqa
-import postgres  # noqa
-import rdbhost  # noqa
-import sqlite  # noqa
-import sybase  # noqa
+from . import firebird  # noqa
+from . import maxdb  # noqa
+from . import mssql  # noqa
+from . import mysql  # noqa
+from . import postgres  # noqa
+from . import rdbhost  # noqa
+from . import sqlite  # noqa
+from . import sybase  # noqa

--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -13,7 +13,6 @@ from .cache import CacheSet
 from . import classregistry
 from . import col
 from .converters import sqlrepr
-import main
 from . import sqlbuilder
 from .util.threadinglocal import local as threading_local
 
@@ -667,6 +666,7 @@ class DBAPI(DBConnection):
                     self.sqlrepr(secondValue)))
 
     def _SO_columnClause(self, soClass, kw):
+        from . import main
         ops = {None: "IS"}
         data = []
         if 'id' in kw:

--- a/sqlobject/dberrors.py
+++ b/sqlobject/dberrors.py
@@ -5,6 +5,9 @@
    http://www.python.org/topics/database/DatabaseAPI-2.0.html
 """
 
+import sys
+if sys.version_info[0] >= 3:
+    StandardError = Exception
 
 class Error(StandardError):
     pass

--- a/sqlobject/declarative.py
+++ b/sqlobject/declarative.py
@@ -33,7 +33,7 @@ or an instance method depending on where it is called.
 """
 
 import copy
-import events
+from . import events
 
 import itertools
 counter = itertools.count()

--- a/sqlobject/events.py
+++ b/sqlobject/events.py
@@ -345,6 +345,7 @@ def nice_repr(v):
 
 
 __all__ = ['listen', 'send']
-for name, value in globals().items():
+# Use copy() to avoid 'dictionary changed' issues on python 3
+for name, value in globals().copy().items():
     if isinstance(value, type) and issubclass(value, Signal):
         __all__.append(name)

--- a/sqlobject/index.py
+++ b/sqlobject/index.py
@@ -1,6 +1,6 @@
 from itertools import count
 from types import *
-from converters import sqlrepr
+from .converters import sqlrepr
 
 
 creationOrder = count()

--- a/sqlobject/joins.py
+++ b/sqlobject/joins.py
@@ -1,9 +1,9 @@
 from itertools import count
-import classregistry
-import events
-import styles
-import sqlbuilder
-from styles import capword
+from . import classregistry
+from . import events
+from . import styles
+from . import sqlbuilder
+from .styles import capword
 
 __all__ = ['MultipleJoin', 'SQLMultipleJoin', 'RelatedJoin', 'SQLRelatedJoin',
            'SingleJoin', 'ManyToMany', 'OneToMany']
@@ -373,7 +373,7 @@ class SingleJoin(Join):
 
 
 
-import boundattributes
+from . import boundattributes
 
 
 class SOManyToMany(object):

--- a/sqlobject/main.py
+++ b/sqlobject/main.py
@@ -28,19 +28,19 @@ USA.
 
 import threading
 import weakref
-import sqlbuilder
-import dbconnection
-import col
-import styles
 import types
 import warnings
-import joins
-import index
-import classregistry
-import declarative
-import events
-from sresults import SelectResults
-from util.threadinglocal import local
+from . import sqlbuilder
+from . import dbconnection
+from . import col
+from . import styles
+from . import joins
+from . import index
+from . import classregistry
+from . import declarative
+from . import events
+from .sresults import SelectResults
+from .util.threadinglocal import local
 
 import sys
 if ((sys.version_info[0] == 2) and (sys.version_info[:3] < (2, 6, 0))) \

--- a/sqlobject/sqlbuilder.py
+++ b/sqlobject/sqlbuilder.py
@@ -66,6 +66,7 @@ import re
 import threading
 import types
 import weakref
+import sys
 
 from . import classregistry
 from .converters import registerConverter, sqlrepr, quote_str, unquote_str
@@ -262,9 +263,15 @@ def tablesUsedSet(obj, db):
         return {}
 
 
+if sys.version_info[0] < 3:
+    div = operator.div
+else:
+    div = operator.truediv
+
+
 operatorMap = {
     "+": operator.add,
-    "/": operator.div,
+    "/": div,
     "-": operator.sub,
     "*": operator.mul,
     "<": operator.lt,

--- a/sqlobject/sqlbuilder.py
+++ b/sqlobject/sqlbuilder.py
@@ -67,8 +67,8 @@ import threading
 import types
 import weakref
 
-import classregistry
-from converters import registerConverter, sqlrepr, quote_str, unquote_str
+from . import classregistry
+from .converters import registerConverter, sqlrepr, quote_str, unquote_str
 
 
 class VersionError(Exception):

--- a/sqlobject/sresults.py
+++ b/sqlobject/sresults.py
@@ -1,5 +1,4 @@
 from . import dbconnection
-import main
 from . import sqlbuilder
 
 
@@ -285,6 +284,7 @@ class SelectResults(object):
         If more than one result is returned,
         ``SQLObjectIntegrityError`` will be raised.
         """
+        from . import main
         results = list(self)
         if not results:
             if default is sqlbuilder.NoDefault:

--- a/sqlobject/sresults.py
+++ b/sqlobject/sresults.py
@@ -1,6 +1,6 @@
-import dbconnection
+from . import dbconnection
 import main
-import sqlbuilder
+from . import sqlbuilder
 
 
 __all__ = ['SelectResults']


### PR DESCRIPTION
This is replaces a number of imports with relative imports, as discussed in issue #3 .

I haven't looked at fixing imports in the test suite yet, so this is not a complete fix.

The commits from 8fc60f4 onwards are minimal workarounds to get py.test to collect the tests on python 3.4, and should not be considered the final solution.