### PR TITLE
Issue 3 fix long syntax

### DIFF
--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -72,6 +72,11 @@ __all__ = ["datetime_available", "mxdatetime_available",
 if mxdatetime_available:
     __all__.append("MXDATETIME_IMPLEMENTATION")
 
+import sys
+if sys.version_info[0] > 2:
+    # alias for python 3 compatability
+    long = int
+
 
 creationOrder = count()
 

--- a/sqlobject/constraints.py
+++ b/sqlobject/constraints.py
@@ -2,6 +2,11 @@
 Constraints
 """
 
+import sys
+if sys.version_info[0] > 2:
+    # alias for python 3 compatability
+    long = int
+
 
 class BadValue(ValueError):
 

--- a/sqlobject/main.py
+++ b/sqlobject/main.py
@@ -47,6 +47,10 @@ if ((sys.version_info[0] == 2) and (sys.version_info[:3] < (2, 6, 0))) \
 or ((sys.version_info[0] == 3) and (sys.version_info[:3] < (3, 4, 0))):
     raise ImportError("SQLObject requires Python 2.6, 2.7 or 3.4+")
 
+if sys.version_info[0] > 2:
+    # alias for python 3 compatability
+    long = int
+
 """
 This thread-local storage is needed for RowCreatedSignals. It gathers
 code-blocks to execute _after_ the whole hierachy of inherited SQLObjects

--- a/sqlobject/tests/test_constraints.py
+++ b/sqlobject/tests/test_constraints.py
@@ -1,6 +1,11 @@
 from sqlobject.constraints import *
 from sqlobject.tests.dbtest import *
 
+import sys
+if sys.version_info[0] > 2:
+    # alias for python 3 compatability
+    long = int
+
 
 def test_constraints():
     obj = 'Test object'
@@ -14,9 +19,9 @@ def test_constraints():
     raises(BadValue, notNull, obj, col, None)
     raises(BadValue, isInt, obj, col, 1.1)
     isInt(obj, col, 1)
-    isInt(obj, col, 1L)
+    isInt(obj, col, long(1))
     isFloat(obj, col, 1)
-    isFloat(obj, col, 1L)
+    isFloat(obj, col, long(1))
     isFloat(obj, col, 1.2)
     raises(BadValue, isFloat, obj, col, '1.0')
 

--- a/sqlobject/tests/test_validation.py
+++ b/sqlobject/tests/test_validation.py
@@ -2,6 +2,10 @@ from sqlobject import *
 from sqlobject.col import validators
 from sqlobject.tests.dbtest import *
 
+import sys
+if sys.version_info[0] > 2:
+    # alias for python 3 compatability
+    long = int
 
 ########################################
 # Validation/conversion
@@ -96,7 +100,7 @@ class TestValidation:
     def test_wrapType(self):
         t = SOValidation(name3=1)
         raises(validators.Invalid, setattr, t, 'name3', 'x')
-        t.name3 = 1L
+        t.name3 = long(1)
         assert t.name3 == 1
         t.name3 = 0
         assert t.name3 == 0


### PR DESCRIPTION
Further work on Issue #3 - this reworks the use of [0-9]L and long to avoid syntax errors on python 3.