### PR TITLE
Issue 3 operator syntax fixes

### DIFF
--- a/docs/SQLBuilder.txt
+++ b/docs/SQLBuilder.txt
@@ -34,7 +34,7 @@ field. All of this is probably easier to grasp in an example::
     person.first_name = 'John'
     >>> name = 'John'
     >>> person.first_name != name
-    person.first_name <> 'John'
+    person.first_name != 'John'
     >>> AND(person.first_name == 'John', person.last_name == 'Doe')
     (person.first_name = 'John' AND person.last_name = 'Doe')
 

--- a/docs/SQLObject.txt
+++ b/docs/SQLObject.txt
@@ -1219,13 +1219,13 @@ different types of columns, when SQLObject creates your tables.
     limitations on using UnicodeCol in queries:
 
     - only simple q-magic fields are supported; no expressions;
-    - only == and <> operators are supported;
+    - only == and != operators are supported;
 
     The following code works::
 
         MyTable.select(u'value' == MyTable.q.name)
-        MyTable.select(MyTable.q.name <> u'value')
-        MyTable.select(OR(MyTable.q.col1 == u'value1', MyTable.q.col2 <> u'value2'))
+        MyTable.select(MyTable.q.name != u'value')
+        MyTable.select(OR(MyTable.q.col1 == u'value1', MyTable.q.col2 != u'value2'))
         MyTable.selectBy(name = u'value')
         MyTable.selectBy(col1=u'value1', col2=u'value2')
         MyTable.byCol1(u'value1') # if col1 is an alternateID

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,7 @@ exclude = .git,docs/europython/*.py,ez_setup.py
 ; W291 trailing whitespace
 ; W293 blank line contains whitespace
 ; W391 blank line at end of file
-; W603 '<>' is deprecated, use '!='
-ignore = E123,E124,E226,E401,E502,F402,F403,F812,F822,W291,W293,W391,W603
+ignore = E123,E124,E226,E401,E502,F402,F403,F812,F822,W291,W293,W391
 
 [pudge]
 theme = pythonpaste.org

--- a/sqlobject/inheritance/tests/test_foreignKey.py
+++ b/sqlobject/inheritance/tests/test_foreignKey.py
@@ -45,13 +45,13 @@ def test_foreignKey():
     assert employee.note.text == "employee"
     save_employee = employee
 
-    persons = PersonWithNotes.select(PersonWithNotes.q.noteID <> None)
+    persons = PersonWithNotes.select(PersonWithNotes.q.noteID != None)
     assert persons.count() == 2
 
     persons = PersonWithNotes.selectBy(noteID=person.note.id)
     assert persons.count() == 1
 
-    employee = EmployeeWithNotes.select(PersonWithNotes.q.noteID <> None)
+    employee = EmployeeWithNotes.select(PersonWithNotes.q.noteID != None)
     assert employee.count() == 1
 
     persons = PersonWithNotes.selectBy(noteID=person.note.id)

--- a/sqlobject/inheritance/tests/test_inheritance.py
+++ b/sqlobject/inheritance/tests/test_inheritance.py
@@ -50,19 +50,19 @@ def test_inheritance():
 def test_inheritance_select():
     setup()
 
-    persons = InheritablePerson.select(InheritablePerson.q.firstName <> None)
+    persons = InheritablePerson.select(InheritablePerson.q.firstName != None)
     assert persons.count() == 2
 
     persons = InheritablePerson.select(InheritablePerson.q.firstName == "phd")
     assert persons.count() == 0
 
-    employees = Employee.select(Employee.q.firstName <> None)
+    employees = Employee.select(Employee.q.firstName != None)
     assert employees.count() == 1
 
     employees = Employee.select(Employee.q.firstName == "phd")
     assert employees.count() == 0
 
-    employees = Employee.select(Employee.q.position <> None)
+    employees = Employee.select(Employee.q.position != None)
     assert employees.count() == 1
 
     persons = InheritablePerson.selectBy(firstName="Project")

--- a/sqlobject/tests/test_comparison.py
+++ b/sqlobject/tests/test_comparison.py
@@ -21,4 +21,4 @@ def test_eq():
     assert t2 is not t4
     assert t1 == t3
     assert t2 == t4
-    assert t1 <> t2
+    assert t1 != t2


### PR DESCRIPTION
Further work related to issues #3. '<>' is illegal syntax in python3. This replaces it with '!=' throughout, and updates the docs to avoid mentioning '!='.

