### PR TITLE
Issue 48: Fix E121 - continuation line under-indented for hanging indent

### DIFF
--- a/sqlobject/inheritance/__init__.py
+++ b/sqlobject/inheritance/__init__.py
@@ -4,7 +4,7 @@ from sqlobject import events
 from sqlobject import sqlbuilder
 from sqlobject.col import StringCol, ForeignKey
 from sqlobject.main import sqlmeta, SQLObject, SelectResults, \
-   makeProperties, unmakeProperties, getterName, setterName
+    makeProperties, unmakeProperties, getterName, setterName
 from . import iteration
 
 

--- a/sqlobject/sresults.py
+++ b/sqlobject/sresults.py
@@ -29,7 +29,7 @@ class SelectResults(object):
             del ops['connection']
         if ops.get('limit', None):
             assert not ops.get('start', None) and not ops.get('end', None), \
-               "'limit' cannot be used with 'start' or 'end'"
+                "'limit' cannot be used with 'start' or 'end'"
             ops["start"] = 0
             ops["end"] = ops.pop("limit")
 


### PR DESCRIPTION
Fixes #48 - E121 - continuation line under-indented for hanging indent

(only 2 instances as the other cases originally reported have been fixed in other cleanups)