### PR TITLE
Tweak test_md5 to be compatible with python 3

### DIFF
--- a/sqlobject/tests/test_md5.py
+++ b/sqlobject/tests/test_md5.py
@@ -7,7 +7,7 @@ from hashlib import md5
 
 
 def test_md5():
-    assert md5('').hexdigest() == 'd41d8cd98f00b204e9800998ecf8427e'
-    assert md5('\n').hexdigest() == '68b329da9893e34099c7d8ad5cb9c940'
-    assert md5('123').hexdigest() == '202cb962ac59075b964b07152d234b70'
-    assert md5('123\n').hexdigest() == 'ba1f2511fc30423bdbb183fe33f3dd0f'
+    assert md5(b'').hexdigest() == 'd41d8cd98f00b204e9800998ecf8427e'
+    assert md5(b'\n').hexdigest() == '68b329da9893e34099c7d8ad5cb9c940'
+    assert md5(b'123').hexdigest() == '202cb962ac59075b964b07152d234b70'
+    assert md5(b'123\n').hexdigest() == 'ba1f2511fc30423bdbb183fe33f3dd0f'


### PR DESCRIPTION
test_md5 can be trivially changed to be compatible across python 2.6, 2.7 and 3.X.