### PR TITLE
Rewrite parse uri to use urlparse

### DIFF
--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -213,6 +213,12 @@ class DBConnection:
     @staticmethod
     def _parseURI(uri):
         parsed = urlparse(uri)
+        if sys.version_info[0] == 2 and sys.version_info[1] < 7:
+            # In python 2.6, urlparse only parses the uri completely
+            # for certain schemes, so we force the scheme to
+            # something that will be parsed correctly
+            scheme = parsed.scheme
+            parsed = urlparse(uri.replace(scheme, 'http', 1))
         host, path = parsed.hostname, parsed.path
         user, password, port = None, None, None
         if parsed.username:


### PR DESCRIPTION
The current _parseURI method uses a lot of urllib functions that have been deprecated or replaced in python 3, which makes supporting python 2 & 3 diffcult with the current code.

This rewrites _parseURI to use urlparse on python 2, and uses the close correspondence between urlparse and urllib.parse in python 3 to handle compatibility with python 3.