### PR TITLE
Replace count.next() with next(count) to be compatible with python 3

### DIFF
--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -421,7 +421,7 @@ class Col(object):
         super(Col, self).__init__()
         self.__dict__['_name'] = name
         self.__dict__['_kw'] = kw
-        self.__dict__['creationOrder'] = creationOrder.next()
+        self.__dict__['creationOrder'] = next(creationOrder)
         self.__dict__['_extra_vars'] = {}
 
     def _set_name(self, value):

--- a/sqlobject/declarative.py
+++ b/sqlobject/declarative.py
@@ -108,7 +108,7 @@ class Declarative(object):
     __restrict_attributes__ = None
 
     def __classinit__(cls, new_attrs):
-        cls.declarative_count = counter.next()
+        cls.declarative_count = next(counter)
         for name in cls.__mutableattributes__:
             if name not in new_attrs:
                 setattr(cls, copy.copy(getattr(cls, name)))
@@ -123,7 +123,7 @@ class Declarative(object):
         for name, value in new_attrs.items():
             setattr(self, name, value)
         if 'declarative_count' not in new_attrs:
-            self.declarative_count = counter.next()
+            self.declarative_count = next(counter)
 
     def __init__(self, *args, **kw):
         if self.__unpackargs__ and self.__unpackargs__[0] == '*':

--- a/sqlobject/index.py
+++ b/sqlobject/index.py
@@ -161,7 +161,7 @@ class DatabaseIndex(object):
     def __init__(self, *columns, **kw):
         kw['columns'] = columns
         self.kw = kw
-        self.creationOrder = creationOrder.next()
+        self.creationOrder = next(creationOrder)
 
     def setName(self, value):
         assert self.kw.get('name') is None, \

--- a/sqlobject/joins.py
+++ b/sqlobject/joins.py
@@ -25,7 +25,7 @@ class Join(object):
         kw['otherClass'] = otherClass
         self.kw = kw
         self._joinMethodName = self.kw.pop('joinMethodName', None)
-        self.creationOrder = creationOrder.next()
+        self.creationOrder = next(creationOrder)
 
     def _set_joinMethodName(self, value):
         assert self._joinMethodName == value or self._joinMethodName is None, \


### PR DESCRIPTION
Python 3 drops the .next  method on iterators. This reworks the use of itertools.count to use the next() function for python 3 compatibility.