### PR TITLE
sqlite3.Binary expects to be called with a bytes object on python 3

### DIFF
--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -339,7 +339,7 @@ class DBAPI(DBConnection):
         self._pool = []
         self._poolLock = threading.Lock()
         DBConnection.__init__(self, **kw)
-        self._binaryType = type(self.module.Binary(''))
+        self._binaryType = type(self.module.Binary(b''))
 
     def _runWithConnection(self, meth, *args):
         conn = self.getConnection()


### PR DESCRIPTION
This fixes a number of ` TypeError: expected bytes-like object, not str` errors on python 3.

AFAIK, pyscopg on python3 also wants a bytes object for it's Binary method.