### PR TITLE
Change lookupConverter to handle python 3 behaviour

### DIFF
--- a/sqlobject/converters.py
+++ b/sqlobject/converters.py
@@ -57,10 +57,15 @@ class ConverterRegistry:
             self.basic[typ] = func
 
     def lookupConverter(self, value, default=None):
-        if type(value) is InstanceType:
-            # lookup on klasses dict
+        if sys.version_info[0] < 3:
+            if type(value) is InstanceType:
+                # lookup on klasses dict
+                return self.klass.get(value.__class__, default)
+            return self.basic.get(type(value), default)
+        else:
+            # python 3 doesn't have classic classes, so everything's
+            # in self.klass
             return self.klass.get(value.__class__, default)
-        return self.basic.get(type(value), default)
 
 converters = ConverterRegistry()
 registerConverter = converters.registerConverter

--- a/sqlobject/converters.py
+++ b/sqlobject/converters.py
@@ -56,13 +56,14 @@ class ConverterRegistry:
         else:
             self.basic[typ] = func
 
-    def lookupConverter(self, value, default=None):
-        if sys.version_info[0] < 3:
+    if sys.version_info[0] < 3:
+        def lookupConverter(self, value, default=None):
             if type(value) is InstanceType:
                 # lookup on klasses dict
                 return self.klass.get(value.__class__, default)
             return self.basic.get(type(value), default)
-        else:
+    else:
+        def lookupConverter(self, value, default=None):
             # python 3 doesn't have classic classes, so everything's
             # in self.klass
             return self.klass.get(value.__class__, default)

--- a/sqlobject/converters.py
+++ b/sqlobject/converters.py
@@ -65,7 +65,7 @@ class ConverterRegistry:
     else:
         def lookupConverter(self, value, default=None):
             # python 3 doesn't have classic classes, so everything's
-            # in self.klass
+            # in self.klass due to comparison order in registerConvertor
             return self.klass.get(value.__class__, default)
 
 converters = ConverterRegistry()


### PR DESCRIPTION
The distinction between old-style and new-style classes used to place convertors in the basic and klass dictionaries doesn't exist in python 3, so everything is in the klass dictionary there. This changes the lookup behaviour to account for that difference.