### PR TITLE
Don't encode strings back to bytes in python 3

### DIFF
--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -564,7 +564,9 @@ class StringValidator(SOValidator):
             binaryType = type(None)  # Just a simple workaround
         dbEncoding = self.getDbEncoding(state, default='ascii')
         if isinstance(value, unicode_type):
-            return value.encode(dbEncoding)
+            if sys.version_info[0] < 3:
+                return value.encode(dbEncoding)
+            return value
         if self.dataType and isinstance(value, self.dataType):
             return value
         if isinstance(value,


### PR DESCRIPTION
This changes the behaviour of StringValidator to return strings on python 3. There are probably more efficient ways to handle this, but that is something we can revisit later.