### PR TITLE
On python3, zipfile deals in bytes

### DIFF
--- a/sqlobject/tests/test_csvexport.py
+++ b/sqlobject/tests/test_csvexport.py
@@ -96,6 +96,6 @@ def test_zip():
     ComplexCSV(fname='Bob', lname='Dylan', age=60)
     ComplexCSV(fname='Harriet', lname='Tubman', age=160)
     s = export_csv_zip([SimpleCSV, ComplexCSV])
-    assert isinstance(s, str) and s
+    assert isinstance(s, bytes) and s
     s = export_csv_zip([SimpleCSV.selectBy(name='Bob'),
                         (ComplexCSV, list(ComplexCSV.selectBy(fname='John')))])

--- a/sqlobject/util/csvexport.py
+++ b/sqlobject/util/csvexport.py
@@ -3,13 +3,14 @@ Exports a SQLObject class (possibly annotated) to a CSV file.
 """
 import os
 import csv
+import sys
 try:
     from cStringIO import StringIO
 except ImportError:
     try:
         from StringIO import StringIO
     except ImportError:
-        from io import StringIO
+        from io import StringIO, BytesIO
 import sqlobject
 from sqlobject.compat import string_type
 
@@ -168,7 +169,11 @@ def export_csv_zip(soClasses, file=None, zip=None, filename_prefix='',
         close_zip_when_finished = False
     else:
         return_when_finished = True
-        file = StringIO()
+        if sys.version_info[0] < 3:
+            file = StringIO()
+        else:
+            # zipfile on python3 requires BytesIO
+            file = BytesIO()
 
     if not zip:
         zip = zipfile.ZipFile(file, mode='w')


### PR DESCRIPTION
On python 3, zipfile outputs bytes, so we need to use BytesIO and update the test to reflect this.