### PR TITLE
Use BytesIO unconditionally

### DIFF
--- a/sqlobject/util/csvexport.py
+++ b/sqlobject/util/csvexport.py
@@ -3,14 +3,8 @@ Exports a SQLObject class (possibly annotated) to a CSV file.
 """
 import os
 import csv
-import sys
-try:
-    from cStringIO import StringIO
-except ImportError:
-    try:
-        from StringIO import StringIO
-    except ImportError:
-        from io import StringIO, BytesIO
+
+from io import BytesIO, StringIO
 import sqlobject
 from sqlobject.compat import string_type
 
@@ -169,11 +163,7 @@ def export_csv_zip(soClasses, file=None, zip=None, filename_prefix='',
         close_zip_when_finished = False
     else:
         return_when_finished = True
-        if sys.version_info[0] < 3:
-            file = StringIO()
-        else:
-            # zipfile on python3 requires BytesIO
-            file = BytesIO()
+        file = BytesIO()
 
     if not zip:
         zip = zipfile.ZipFile(file, mode='w')


### PR DESCRIPTION
There's no need to branch on the version of python if the content is always bytes.

We're also only supporting Python 2.6 plus, so there's no need to conditionally import anything from `cStringIO` or `StringIO` since the `io` module exists on all of the currently supported versions.