### PR TITLE
map no longer returns a list on python 3, so explicitly convert it

### DIFF
--- a/sqlobject/sresults.py
+++ b/sqlobject/sresults.py
@@ -22,7 +22,7 @@ class SelectResults(object):
             ops['orderBy'] = sourceClass.sqlmeta.defaultOrder
         orderBy = ops['orderBy']
         if isinstance(orderBy, (tuple, list)):
-            orderBy = map(self._mungeOrderBy, orderBy)
+            orderBy = list(map(self._mungeOrderBy, orderBy))
         else:
             orderBy = self._mungeOrderBy(orderBy)
         ops['dbOrderBy'] = orderBy


### PR DESCRIPTION
Fix the behaviour of orderBy in python 3

It may be better to tweak Select.__sqlrepr__ to treat iterators the same as it treats list in orderBy clauses, but this is a minimal fix.