### PR TITLE
Rework blob columns

### DIFF
--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -1671,6 +1671,8 @@ class BinaryValidator(SOValidator):
             binaryType = connection._binaryType
         if isinstance(value, str):
             if dbName == "sqlite":
+                if sys.version_info[0] > 2:
+                    value = bytes(value, 'ascii')
                 value = connection.module.decode(value)
             return value
         if isinstance(value, (buffer_type, binaryType)):
@@ -1679,6 +1681,8 @@ class BinaryValidator(SOValidator):
                 return cachedValue[0]
             if isinstance(value, array):  # MySQL
                 return value.tostring()
+            if sys.version_info[0] > 2 and isinstance(value, memoryview):
+                return value.tobytes()
             return str(value)  # buffer => string
         raise validators.Invalid(
             "expected a string in the BLOBCol '%s', got %s %r instead" % (
@@ -1689,6 +1693,8 @@ class BinaryValidator(SOValidator):
             return None
         connection = state.connection or state.soObject._connection
         binary = connection.createBinary(value)
+        if sys.version_info[0] > 2 and isinstance(binary, memoryview):
+            binary = str(binary.tobytes(), 'ascii')
         self._cachedValue = (value, binary)
         return binary
 

--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -1752,7 +1752,7 @@ class PickleValidator(BinaryValidator):
         if isinstance(value, unicode_type):
             dbEncoding = self.getDbEncoding(state, default='ascii')
             value = value.encode(dbEncoding)
-        if isinstance(value, str):
+        if isinstance(value, bytes):
             return pickle.loads(value)
         raise validators.Invalid(
             "expected a pickle string in the PickleCol '%s', "

--- a/sqlobject/tests/test_blob.py
+++ b/sqlobject/tests/test_blob.py
@@ -1,3 +1,4 @@
+import sys
 import py.test
 from sqlobject import *
 from sqlobject.tests.dbtest import *
@@ -9,14 +10,17 @@ from sqlobject.tests.dbtest import *
 
 
 class ImageData(SQLObject):
-    image = BLOBCol(default='emptydata', length=65535)
+    image = BLOBCol(default=b'emptydata', length=65535)
 
 
 def test_BLOBCol():
     if not supports('blobData'):
         py.test.skip("blobData isn't supported")
     setupClass(ImageData)
-    data = ''.join([chr(x) for x in range(256)])
+    if sys.version_info[0] == 2:
+        data = ''.join([chr(x) for x in range(256)])
+    else:
+        data = bytes(range(256))
 
     prof = ImageData()
     prof.image = data


### PR DESCRIPTION
This reworks SQLObject's BLOB column to accept and return bytes on python 3, which is I believe the correct thing for it to do.

Most of the futzing around between str / byte conversions is because  BLOBColums falls back to StringCol for sqlite. I'm not sure if ascii is the best choice of codec to use for this, but it works for sqlite because of the base64 conversion in sqliteconnection.encode. This code isn't hit by postgres, but it may need to be looked at for other database backends.