### PR TITLE
Update doctests

### DIFF
--- a/docs/SQLObject.txt
+++ b/docs/SQLObject.txt
@@ -301,8 +301,8 @@ same actions with the SQL that is sent, along with some commentary::
     >>> # This will make SQLObject print out the SQL it executes:
     >>> Person._connection.debug = True
     >>> p = Person(firstName='Bob', lastName='Hope')
-     1/QueryIns:  INSERT INTO person (last_name, middle_initial, first_name) VALUES ('Hope', NULL, 'Bob')
-     1/QueryR  :  INSERT INTO person (last_name, middle_initial, first_name) VALUES ('Hope', NULL, 'Bob')
+     1/QueryIns:  INSERT INTO person (first_name, middle_initial, last_name) VALUES ('Bob', NULL, 'Hope')
+     1/QueryR  :  INSERT INTO person (first_name, middle_initial, last_name) VALUES ('Bob', NULL, 'Hope')
      1/COMMIT  :  auto
      1/QueryOne:  SELECT first_name, middle_initial, last_name FROM person WHERE ((person.id) = (2))
      1/QueryR  :  SELECT first_name, middle_initial, last_name FROM person WHERE ((person.id) = (2))

--- a/docs/SQLObject.txt
+++ b/docs/SQLObject.txt
@@ -355,16 +355,19 @@ that's generated)::
      1/COMMIT  :  auto
     [<Person 1 firstName='John' middleInitial='Q' lastName='Doe'>]
 
-This example returns everyone with the first name John.  An expression
-could be more complicated as well, like::
+This example returns everyone with the first name John.
+
+Queries can be more complex::
 
     >>> peeps = Person.select(
-    ...         AND(Address.q.personID == Person.q.id,
-    ...             Address.q.zip.startswith('504')))
+    ...         OR(Person.q.firstName == "John",
+    ...            LIKE(Person.q.lastName, "%Hope%")))
     >>> list(peeps)
-     1/Select  :  SELECT person.id, person.first_name, person.middle_initial, person.last_name FROM person, address WHERE ((address.person_id = person.id) AND (address.zip LIKE '504%'))
+     1/Select  :  SELECT person.id, person.first_name, person.middle_initial, person.last_name FROM person WHERE (((person.first_name) = ('John')) OR (person.last_name LIKE ('%Hope%')))
+     1/QueryR  :  SELECT person.id, person.first_name, person.middle_initial, person.last_name FROM person WHERE (((person.first_name) = ('John')) OR (person.last_name LIKE ('%Hope%')))
      1/COMMIT  :  auto
-    []
+    [<Person 1 firstName='John' middleInitial='Q' lastName='Doe'>, <Person 2 firstName='Robert' middleInitial='Q' lastName='Hope Jr.'>]
+
 
 You'll note that classes have an attribute ``q``, which gives access
 to special objects for constructing query clauses.  All attributes
@@ -372,15 +375,10 @@ under ``q`` refer to column names and if you construct logical
 statements with these it'll give you the SQL for that statement.  You
 can also create your SQL more manually::
 
-    >>> Person._connection.debug = False  # Needed for doctests
-    >>> peeps = Person.select("""address.person_id = person.id AND
-    ...                          address.zip LIKE '504%'""",
-    ...                       clauseTables=['address'])
+    >>> Person._connection.debug = False  # Need for doctests
+    >>> peeps = Person.select("""person.first_name = 'John' AND
+    ...                          person.last_name LIKE 'D%'""")
 
-Note that you have to use ``clauseTables`` if you use tables besides
-the one you are selecting from.  If you use the ``q`` attributes
-SQLObject will automatically figure out what extra classes you might
-have used.
 
 You should use `MyClass.sqlrepr` to quote any values you use if you
 create SQL manually (quoting is automatic if you use ``q``).
@@ -695,6 +693,38 @@ keyword argument to override this).  Its use:
     <User 1 username='bob'>
     >>> Role.byName('admin')
     <Role 1 name='admin'>
+
+
+Selecting Objects Using Relationships
+-------------------------------------
+
+An select expression can refer to multiple classes, like::
+
+    >>> Person._connection.debug = False # Needed for doctests
+    >>> peeps = Person.select(
+    ...         AND(Address.q.personID == Person.q.id,
+    ...             Address.q.zip.startswith('504')))
+    >>> list(peeps)
+    []
+    >>> peeps = Person.select(
+    ...         AND(Address.q.personID == Person.q.id,
+    ...             Address.q.zip.startswith('554')))
+    >>> list(peeps)
+    [<Person 2 firstName='Robert' middleInitial='Q' lastName='Hope Jr.'>]
+
+
+It is also possible to use the ``q`` attribute when constructing complex
+queries, like::
+
+    >>> Person._connection.debug = False  # Needed for doctests
+    >>> peeps = Person.select("""address.person_id = person.id AND
+    ...                          address.zip LIKE '504%'""",
+    ...                       clauseTables=['address'])
+
+Note that you have to use ``clauseTables`` if you use tables besides
+the one you are selecting from.  If you use the ``q`` attributes
+SQLObject will automatically figure out what extra classes you might
+have used.
 
 Class sqlmeta
 -------------


### PR DESCRIPTION
The doctests  in SQLObject.txt currently fail due to two issues.

The first is the ordering of columns during inserts was changed recently, and the test was never updated to reflect that.

The second breakage is due to the examples in "Selecting Multiple Objects" using a join example before joins are discussed and the appropriate tables created. I've addressed this by reworking the documentation to only discussion selections with joins after discussing the various types of relationship.

With these fixes, the doctests pass with both python 2.7 and python 3.4