### PR TITLE
Flag python2 compatibility definitions for flake8

### DIFF
--- a/sqlobject/compat.py
+++ b/sqlobject/compat.py
@@ -18,10 +18,11 @@ def with_metaclass(meta, *bases):
 
 # Compatability definitions (inspired by six)
 if sys.version_info[0] < 3:
-    string_type = basestring
-    unicode_type = unicode
+    # disable flake8 checks on python 3
+    string_type = basestring  # noqa
+    unicode_type = unicode  # noqa
     class_types = (type, types.ClassType)
-    buffer_type = buffer
+    buffer_type = buffer  # noqa
 else:
     string_type = str
     unicode_type = str

--- a/sqlobject/converters.py
+++ b/sqlobject/converters.py
@@ -96,7 +96,8 @@ def StringLikeConverter(value, db):
 
 registerConverter(str, StringLikeConverter)
 if sys.version_info[0] < 3:
-    registerConverter(unicode, StringLikeConverter)
+    # noqa for flake8 & python3
+    registerConverter(unicode, StringLikeConverter)  # noqa
 registerConverter(array, StringLikeConverter)
 if sys.version_info[0] < 3:
     registerConverter(buffer_type, StringLikeConverter)
@@ -114,7 +115,8 @@ def LongConverter(value, db):
     return str(value)
 
 if sys.version_info[0] < 3:
-    registerConverter(long, LongConverter)
+    # noqa for flake8 & python3
+    registerConverter(long, LongConverter)  # noqa
 
 if NumericType:
     registerConverter(NumericType, IntConverter)


### PR DESCRIPTION
This silences some flake8 warnings on python 3.4 that occur in python 2x only code.