### PR TITLE
Mysql support for python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TOXENV=py27-sqlite
   - TOXENV=py34-sqlite
   - TOXENV=py34-postgres
+  - TOXENV=py34-mysqlclient
   - TOXENV=py27-flake8
   - TOXENV=py34-flake8
 
@@ -19,6 +20,7 @@ matrix:
   allow_failures:
     - env: TOXENV=py34-sqlite
     - env: TOXENV=py34-postgres
+    - env: TOXENV=py34-mysqlclient
     - env: TOXENV=py34-flake8
 
 script: tox -e ${TOXENV}

--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -1714,12 +1714,13 @@ class SOBLOBCol(SOStringCol):
     def _mysqlType(self):
         length = self.length
         varchar = self.varchar
-        if length >= 2 ** 24:
-            return varchar and "LONGTEXT" or "LONGBLOB"
-        if length >= 2 ** 16:
-            return varchar and "MEDIUMTEXT" or "MEDIUMBLOB"
-        if length >= 2 ** 8:
-            return varchar and "TEXT" or "BLOB"
+        if length:
+            if length >= 2 ** 24:
+                return varchar and "LONGTEXT" or "LONGBLOB"
+            if length >= 2 ** 16:
+                return varchar and "MEDIUMTEXT" or "MEDIUMBLOB"
+            if length >= 2 ** 8:
+                return varchar and "TEXT" or "BLOB"
         return varchar and "TINYTEXT" or "TINYBLOB"
 
     def _postgresType(self):
@@ -1778,10 +1779,11 @@ class SOPickleCol(SOBLOBCol):
 
     def _mysqlType(self):
         length = self.length
-        if length >= 2 ** 24:
-            return "LONGBLOB"
-        if length >= 2 ** 16:
-            return "MEDIUMBLOB"
+        if length:
+            if length >= 2 ** 24:
+                return "LONGBLOB"
+            if length >= 2 ** 16:
+                return "MEDIUMBLOB"
         return "BLOB"
 
 

--- a/sqlobject/mysql/mysqlconnection.py
+++ b/sqlobject/mysql/mysqlconnection.py
@@ -5,8 +5,8 @@ from sqlobject.dbconnection import DBAPI
 
 class ErrorMessage(str):
     def __new__(cls, e, append_msg=''):
-        obj = str.__new__(cls, e[1] + append_msg)
-        obj.code = int(e[0])
+        obj = str.__new__(cls, e.args[1] + append_msg)
+        obj.code = int(e.args[0])
         obj.module = e.__module__
         obj.exception = e.__class__.__name__
         return obj
@@ -207,7 +207,7 @@ class MySQLConnection(DBAPI):
             self.query('DESCRIBE %s' % (tableName))
             return True
         except dberrors.ProgrammingError as e:
-            if e[0].code == 1146:  # ER_NO_SUCH_TABLE
+            if e.args[0].code == 1146:  # ER_NO_SUCH_TABLE
                 return False
             raise
 

--- a/sqlobject/mysql/mysqlconnection.py
+++ b/sqlobject/mysql/mysqlconnection.py
@@ -1,3 +1,4 @@
+import sys
 from sqlobject import col
 from sqlobject import dberrors
 from sqlobject.dbconnection import DBAPI
@@ -10,6 +11,8 @@ class ErrorMessage(str):
         obj.module = e.__module__
         obj.exception = e.__class__.__name__
         return obj
+
+mysql_Bin = None
 
 
 class MySQLConnection(DBAPI):
@@ -44,6 +47,12 @@ class MySQLConnection(DBAPI):
             self.dbEncoding = self.kw["charset"] = kw.pop("charset")
         else:
             self.dbEncoding = None
+
+        global mysql_Bin
+        if sys.version_info[0] > 2 and mysql_Bin is None:
+            mysql_Bin = MySQLdb.Binary
+            MySQLdb.Binary = lambda x: mysql_Bin(x).decode(
+                'ascii', errors='surrogateescape')
 
         # MySQLdb < 1.2.1: only ascii
         # MySQLdb = 1.2.1: only unicode

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27}-mysql,{py26,py27,py34}-postgres,{py26,py27,py34}-sqlite,{py27,py34}-flake8
+envlist = {py26,py27}-mysql,{py26,py27,py34}-postgres,{py26,py27,py34}-sqlite,{py27,py34}-flake8,py34-mysqlclient
 
 # Base test environment settings
 [testenv]
@@ -19,6 +19,7 @@ deps =
     FormEncode >= 1.1.1
     PyDispatcher>=2.0.4
     mysql: mysql-python
+    mysqlclient: mysqlclient
     postgres: psycopg2
 
 
@@ -66,6 +67,12 @@ commands =
     psql -c 'create database sqlobject_test;' -U postgres
     py.test -D postgres://postgres:@localhost/sqlobject_test
     psql -c 'drop database sqlobject_test;' -U postgres
+
+[testenv:py34-mysqlclient]
+commands =
+    mysql -e 'create database sqlobject_test;'
+    py.test -D mysql://root:@localhost/sqlobject_test
+    mysql -e 'drop database sqlobject_test;'
 
 [testenv:py27-flake8]
 basepython = python2.7


### PR DESCRIPTION
This supports mysql on python 3 using mysqlclient (https://pypi.python.org/pypi/mysqlclient), which seems to be the most active of the MySQLdb forks supporting python 3. This also adds a py3.4 & mysqlclient test run to tox.

In addition to the test_unicode and test_validation failures we have with the other database backends, there's a failure in test_enum. I have not investigated this at all.

There's probably a simpler way of handling the bytes encoding requirements for mysqlclient than I've used in  63d714a , but that's a polish issue.