### PR TITLE
Force charset for MySQL to be utf8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 [testenv:py34-mysqlclient]
 commands =
     mysql -e 'create database sqlobject_test;'
-    py.test -D mysql://root:@localhost/sqlobject_test
+    py.test -D mysql://root:@localhost/sqlobject_test?charset=utf8
     mysql -e 'drop database sqlobject_test;'
 
 [testenv:py27-flake8]


### PR DESCRIPTION
Default charset for MySQL is latin-1.