### PR TITLE
Try use fdb first before falling back to kinterbasdb

### DIFF
--- a/sqlobject/firebird/firebirdconnection.py
+++ b/sqlobject/firebird/firebirdconnection.py
@@ -20,10 +20,15 @@ class FirebirdConnection(DBAPI):
                  dialect=None, role=None, charset=None, **kw):
         global kinterbasdb
         if kinterbasdb is None:
-            import kinterbasdb
-            # See http://kinterbasdb.sourceforge.net/dist_docs/usage.html
-            # for an explanation; in short: use datetime, decimal and unicode.
-            kinterbasdb.init(type_conv=200)
+            try:
+                import fdb
+                kinterbasdb = fdb
+            except ImportError:
+                import kinterbasdb
+                # See http://kinterbasdb.sourceforge.net/dist_docs/usage.html
+                # for an explanation; in short: use datetime, decimal and
+                # unicode.
+                kinterbasdb.init(type_conv=200)
         self.module = kinterbasdb
 
         self.host = host


### PR DESCRIPTION
kinterdasdb is obselete, and the recommended driver for firebird is now fdb.

This patch tries fdb as the default driver before attempting to use kinterbasdb.

The test suite doesn't pass with either backend, but the same tests fail for both backends, so there is no regression using fdb