### PR TITLE
Fix issue 128 by dropping the table name from the call

### DIFF
--- a/sqlobject/sqlite/sqliteconnection.py
+++ b/sqlobject/sqlite/sqliteconnection.py
@@ -310,7 +310,7 @@ class SQLiteConnection(DBAPI):
         self.query('ALTER TABLE %s ADD COLUMN %s' %
                    (tableName,
                     column.sqliteCreateSQL()))
-        self.query('VACUUM %s' % tableName)
+        self.query('VACUUM')
 
     def delColumn(self, sqlmeta, column):
         self.recreateTableWithoutColumn(sqlmeta, column)


### PR DESCRIPTION
SQLite 3.15 treats the parameter to VACUUM as a schema name,
not the table name. Dropping the parameter matches the
behaviour on older versions, which simply ignored the parameter.

This addresses #128 