### PR TITLE
Feature/enable firebird testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,9 @@ env:
   - TOXENV=py35-sqlite
   - TOXENV=py27-flake8
   - TOXENV=py34-flake8
-  - TOXENV=py27-firebird
-  - TOXENV=py34-firebird
-  - TOXENV=py35-firebird
+  - TOXENV=py27-fdb
+  - TOXENV=py34-fdb
+  - TOXENV=py35-fdb
   - TOXENV=py27-firebirdsql
   - TOXENV=py34-firebirdsql
   - TOXENV=py35-firebirdsql
@@ -79,6 +79,9 @@ matrix:
     - env: TOXENV=py27-pg8000
     - env: TOXENV=py34-pg8000
     - env: TOXENV=py35-pg8000
+    - env: TOXENV=py27-fdb
+    - env: TOXENV=py34-fdb
+    - env: TOXENV=py35-fdb
   fast_finish: true
 
 script: tox -e ${TOXENV}

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,9 @@ matrix:
     - env: TOXENV=py27-fdb
     - env: TOXENV=py34-fdb
     - env: TOXENV=py35-fdb
+    - env: TOXENV=py27-firebirdsql
+    - env: TOXENV=py34-firebirdsql
+    - env: TOXENV=py35-firebirdsql
   fast_finish: true
 
 script: tox -e ${TOXENV}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,16 @@ addons:
       - python-mysqldb
       - python-psycopg2
       - python3-psycopg2
-      - firebird2.5-classic
+      - firebird2.5-super
   postgresql: "9.4"
 
+# Start the firebird database server
+# We use firebird-super, so there's none of the inetd configuration required by firebird-classic
+# We also create a test user for the firebird test and create a script that can be fed into isql-fb to create the test database
 before_install:
-   # Create a test user for firebird
-   SYS_PASS=$(grep ISC_PASSWORD /etc/firebird/2.5/SYSDBA.password | cut -d '"' -f 2)
-   sudo gsec -user sysdba -pass $SYS_PASS -add test -pw test
+   - sudo sed -i /etc/default/firebird2.5 -e 's/=no/=yes/' && sudo /etc/init.d/firebird2.5-super start
+   - sudo touch /var/lib/firebird/create_test_db && sudo chmod 666 /var/lib/firebird/create_test_db && echo "CREATE DATABASE 'localhost:/tmp/test.fdb';" > /var/lib/firebird/create_test_db && sudo chmod 644 /var/lib/firebird/create_test_db
+   - sudo gsec -user sysdba -pass masterkey -add test -pw test
 
 env:
   - TOXENV=py26-mysqldb

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ addons:
       - python-mysqldb
       - python-psycopg2
       - python3-psycopg2
+      - firebird2.5-classic
   postgresql: "9.4"
+
+before_install:
+   # Create a test user for firebird
+   SYS_PASS=$(grep ISC_PASSWORD /etc/firebird/2.5/SYSDBA.password | cut -d '"' -f 2)
+   sudo gsec -user sysdba -pass $SYS_PASS -add test -pw test
 
 env:
   - TOXENV=py26-mysqldb
@@ -49,6 +55,12 @@ env:
   - TOXENV=py35-sqlite
   - TOXENV=py27-flake8
   - TOXENV=py34-flake8
+  - TOXENV=py27-firebird
+  - TOXENV=py34-firebird
+  - TOXENV=py35-firebird
+  - TOXENV=py27-firebirdsql
+  - TOXENV=py34-firebirdsql
+  - TOXENV=py35-firebirdsql
 
 install: pip install tox coveralls codecov
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27}-{mysqldb,oursql},{py34,py35}-{mysqlclient,pypostgresql},{py26,py27,py34,py35}-{mysql-connector,pymysql,psycopg,pygresql,pg8000,sqlite},{py27,py34,py35}-{firebird,firebirdsql},{py27,py34}-flake8
+envlist = {py26,py27}-{mysqldb,oursql},{py34,py35}-{mysqlclient,pypostgresql},{py26,py27,py34,py35}-{mysql-connector,pymysql,psycopg,pygresql,pg8000,sqlite},{py27,py34,py35}-{fdb,firebirdsql},{py27,py34}-flake8
 
 # Base test environment settings
 [testenv]
@@ -22,7 +22,7 @@ deps =
     pygresql: pygresql
     pypostgresql: py-postgresql
     pg8000: pg8000
-    firebird: fdb
+    fdb: fdb
     firebirdsql: firebirdsql
 passenv = CI TRAVIS TRAVIS_*
 # Don't fail or warn on uninstalled commands
@@ -203,21 +203,21 @@ commands = {[sqlite]commands}
 commands = {[sqlite]commands}
 
 # Firebird database test environments
-[firebird]
+[fdb]
 commands =
     sudo rm -f /tmp/test.fdb
     isql-fb -u test -p test -i /var/lib/firebird/create_test_db
     pytest --cov=sqlobject -D 'firebird://test:test@localhost/tmp/test.fdb'
     sudo rm /tmp/test.fdb
 
-[testenv:py27-firebird]
-commands = {[firebird]commands}
+[testenv:py27-fdb]
+commands = {[fdb]commands}
 
-[testenv:py34-firebird]
-commands = {[firebird]commands}
+[testenv:py34-fdb]
+commands = {[fdb]commands}
 
-[testenv:py35-firebird]
-commands = {[firebird]commands}
+[testenv:py35-fdb]
+commands = {[fdb]commands}
 
 
 [firebirdsql]

--- a/tox.ini
+++ b/tox.ini
@@ -224,7 +224,7 @@ commands = {[firebird]commands}
 commands =
     sudo rm -f /tmp/test.fdb
     isql-fb -u test -p test -i /var/lib/firebird/create_test_db
-    pytest --cov=sqlobject -D 'firebird://test:test@localhost/tmp/test.fdb?driver=firebirdsql'
+    pytest --cov=sqlobject -D 'firebird://test:test@localhost:3050/tmp/test.fdb?driver=firebirdsql&charset=utf8'
     sudo rm /tmp/test.fdb
 
 [testenv:py27-firebirdsql]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27}-{mysqldb,oursql},{py34,py35}-{mysqlclient,pypostgresql},{py26,py27,py34,py35}-{mysql-connector,pymysql,psycopg,pygresql,pg8000,sqlite},{py27,py34}-flake8
+envlist = {py26,py27}-{mysqldb,oursql},{py34,py35}-{mysqlclient,pypostgresql},{py26,py27,py34,py35}-{mysql-connector,pymysql,psycopg,pygresql,pg8000,sqlite},{py27,py34,py35}-{firebird,firebirdsql},{py27,py34}-flake8
 
 # Base test environment settings
 [testenv]
@@ -22,6 +22,8 @@ deps =
     pygresql: pygresql
     pypostgresql: py-postgresql
     pg8000: pg8000
+    firebird: fdb
+    firebirdsql: firebirdsql
 passenv = CI TRAVIS TRAVIS_*
 # Don't fail or warn on uninstalled commands
 whitelist_externals =
@@ -29,6 +31,9 @@ whitelist_externals =
     createdb
     dropdb
     rm
+    echo
+    sudo
+    isql-fb
 
 # MySQL test environments
 [mysqldb]
@@ -197,6 +202,40 @@ commands = {[sqlite]commands}
 
 [testenv:py35-sqlite]
 commands = {[sqlite]commands}
+
+# Firebird database test environments
+[firebird]
+commands =
+    sudo rm -f /tmp/test.fdb
+    echo "CREATE DATABASE 'localhost:/tmp/test.fdb';" | isql-fb -u test -p test
+    pytest --cov=sqlobject -D 'firebird://test:test@localhost/tmp/test.fdb'
+    sudo rm /tmp/test.fdb
+
+[testenv:py27-firebird]
+commands = {[firebird]commands}
+
+[testenv:py34-firebird]
+commands = {[firebird]commands}
+
+[testenv:py35-firebird]
+commands = {[firebird]commands}
+
+
+[firebirdsql]
+commands =
+    sudo rm -f /tmp/test.fdb
+    echo "CREATE DATABASE 'localhost:/tmp/test.fdb';" | isql-fb -u test -p test
+    pytest --cov=sqlobject -D 'firebird://test:test@localhost/tmp/test.fdb?driver=firebirdsql'
+    sudo rm /tmp/test.fdb
+
+[testenv:py27-firebirdsql]
+commands = {[firebirdsql]commands}
+
+[testenv:py34-firebirdsql]
+commands = {[firebirdsql]commands}
+
+[testenv:py35-firebirdsql]
+commands = {[firebirdsql]commands}
 
 # Special test environments
 [testenv:py27-flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ whitelist_externals =
     createdb
     dropdb
     rm
-    echo
     sudo
     isql-fb
 
@@ -207,7 +206,7 @@ commands = {[sqlite]commands}
 [firebird]
 commands =
     sudo rm -f /tmp/test.fdb
-    echo "CREATE DATABASE 'localhost:/tmp/test.fdb';" | isql-fb -u test -p test
+    isql-fb -u test -p test -i /var/lib/firebird/create_test_db
     pytest --cov=sqlobject -D 'firebird://test:test@localhost/tmp/test.fdb'
     sudo rm /tmp/test.fdb
 
@@ -224,7 +223,7 @@ commands = {[firebird]commands}
 [firebirdsql]
 commands =
     sudo rm -f /tmp/test.fdb
-    echo "CREATE DATABASE 'localhost:/tmp/test.fdb';" | isql-fb -u test -p test
+    isql-fb -u test -p test -i /var/lib/firebird/create_test_db
     pytest --cov=sqlobject -D 'firebird://test:test@localhost/tmp/test.fdb?driver=firebirdsql'
     sudo rm /tmp/test.fdb
 


### PR DESCRIPTION
This adds testing against the firebird database, using both the fdb and firebirdsql drivers, to the test matrix.

This tests with firebird 2.5, since that what's available from the whitelisted repos on travis-ci. Testing against firebird 3.0 will require pulling a package in from a different source. 