### PR TITLE
Feature/add appveyor for windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
       TOX_ENV: "pywin27-mssql"
     - PYTHON: "C:\\Python27"
       db: postgresql
-      TOX_ENV: "pywin27-postgres"
+      TOX_ENV: "pywin27-postgres-psycopg"
     #- PYTHON: "C:\\Python27-x64"
     #  db: mssql2014
     #- PYTHON: "C:\\Python27-x64"
@@ -31,7 +31,7 @@ environment:
       TOX_ENV: "pywin34-mssql"
     - PYTHON: "C:\\Python34"
       db: postgresql
-      TOX_ENV: "pywin34-postgres"
+      TOX_ENV: "pywin34-postgres-psycopg"
     #- PYTHON: "C:\\Python34-x64"
     #  db: mssql2014
     #- PYTHON: "C:\\Python34-x64"
@@ -60,8 +60,6 @@ install:
    - "python --version"
    - "pip install -r requirements.txt"
    - "pip install tox"
-   - "pip install psycopg2"
-   - "echo %PGPASSWORD%"
 
 # Not a C project, so no build step
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ services:
    - postgresql
 
 environment:
-  PGUSER: postgres
-  PGPASSWORD: Password12!
+  PGUSER: "postgres"
+  PGPASSWORD: "Password12!"
 
   matrix:
     # from https://www.appveyor.com/docs/installed-software/#python
@@ -61,6 +61,7 @@ install:
    - "pip install -r requirements.txt"
    - "pip install tox"
    - "pip install psycopg2"
+   - "echo %PGPASSWORD%"
 
 # Not a C project, so no build step
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ version: 3.2.{build}
 clone_depth: 50
 
 services:
-   - mssql2014
    - postgresql
 
 environment:
@@ -60,6 +59,22 @@ install:
    - "python --version"
    - "pip install -r requirements.txt"
    - "pip install tox"
+   # Enable TCP for mssql
+   # (from appveyor documentation)
+   - ps: |
+      [reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null
+      [reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement") | Out-Null
+      $serverName = $env:COMPUTERNAME
+      $instanceName = 'SQL2014'
+      $smo = 'Microsoft.SqlServer.Management.Smo.'
+      $wmi = new-object ($smo + 'Wmi.ManagedComputer')
+      $uri = "ManagedComputer[@Name='$serverName']/ServerInstance[@Name='$instanceName']/ServerProtocol[@Name='Tcp']"
+      $Tcp = $wmi.GetSmoObject($uri)
+      $Tcp.IsEnabled = $true
+      $TCP.alter()
+      Set-Service SQLBrowser -StartupType Manual
+      Start-Service SQLBrowser
+      Start-Service "MSSQL`$$instanceName"
 
 # Not a C project, so no build step
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,69 @@
+# Install SQLObject on windows and test against MS SQL server and postgres
+# Heavily inspired by Oliver Grisel's appveyor-demo (https://github.com/ogrisel/python-appveyor-demo)
+# and Michael Sverdlik's appveyor-utils (https://github.com/cloudify-cosmo/appveyor-utils)
+version: 3.2.{build}
+
+# Match travis
+clone_depth: 50
+
+services:
+   - mssql2014
+   - postgresql
+
+environment:
+  PGUSER: postgres
+  PGPASSWORD: Password12!
+
+  matrix:
+    # from https://www.appveyor.com/docs/installed-software/#python
+    - PYTHON: "C:\\Python27"
+      db: mssql2014
+      TOX_ENV: "pywin27-mssql"
+    - PYTHON: "C:\\Python27"
+      db: postgresql
+      TOX_ENV: "pywin27-postgres"
+    #- PYTHON: "C:\\Python27-x64"
+    #  db: mssql2014
+    #- PYTHON: "C:\\Python27-x64"
+    #  db: postgresql
+    - PYTHON: "C:\\Python34"
+      db: mssql2014
+      TOX_ENV: "pywin34-mssql"
+    - PYTHON: "C:\\Python34"
+      db: postgresql
+      TOX_ENV: "pywin34-postgres"
+    #- PYTHON: "C:\\Python34-x64"
+    #  db: mssql2014
+    #- PYTHON: "C:\\Python34-x64"
+    #  db: postgresql
+    #- PYTHON: "C:\\Python35"
+    #  db: mssql2014
+    #- PYTHON: "C:\\Python35"
+    #  db: postgresql
+    #- PYTHON: "C:\\Python35-x64"
+    #  db: mssql2014
+    #- PYTHON: "C:\\Python35-x64"
+    #  db: postgresql
+    #- PYTHON: "C:\\Python36"
+    #  db: mssql2014
+    #- PYTHON: "C:\\Python36"
+    #  db: postgresql
+    #- PYTHON: "C:\\Python36-x64"
+    #  db: mssql2014
+    #- PYTHON: "C:\\Python36-x64"
+    #  db: postgresql
+
+
+install:
+   # Ensure we use the right python version
+   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\Program Files\\PostgreSQL\\9.5\\bin\\;%PATH%"
+   - "python --version"
+   - "pip install -r requirements.txt"
+   - "pip install tox"
+   - "pip install psycopg2"
+
+# Not a C project, so no build step
+build: false
+
+test_script:
+   - "tox -e %TOX_ENV%"

--- a/tox.ini
+++ b/tox.ini
@@ -257,7 +257,7 @@ commands = flake8 .
 commands =
     -sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "CREATE DATABASE sqlobject_test"
-    pytest -v --timeout=10 --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql"
+    pytest -v --timeout=30 --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql"
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
 
 [winpsycopg]

--- a/tox.ini
+++ b/tox.ini
@@ -256,7 +256,7 @@ commands = flake8 .
 commands =
     -sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "CREATE DATABASE sqlobject_test"
-    pytest --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql"
+    pytest --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql" tests
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
 
 [winpsycopg]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{26,27}-{mysqldb,mysql-oursql},py{34,35}-{mysqlclient,pypostgresql},py{26,27,34,35}-{mysql-connector,pymysql,postgres-psycopg,postgres-pygresql,postgres-pg8000,sqlite},py{27,34,35}-{firebird-fdb,firebirdsql},py{27,34}-flake8
+envlist = py{26,27}-{mysqldb,mysql-oursql},py{34,35}-{mysqlclient,pypostgresql},py{26,27,34,35}-{mysql-connector,pymysql,postgres-psycopg,postgres-pygresql,postgres-pg8000,sqlite},py{27,34,35}-{firebird-fdb,firebirdsql},py{27,34}-flake8,pywin{27,34}-{postgres,mssql}
 
 # Base test environment settings
 [testenv]
@@ -247,3 +247,21 @@ changedir = ./
 deps =
     flake8
 commands = flake8 .
+
+
+# Windows testing
+[winmssql]
+commands =
+   here
+
+[testenv:pywin27-postgres]
+commands = {[psycopg]commands}
+
+[testenv:pywin27-mssql]
+commands = {[winmssql]commands}
+
+[testenv:pywin34-postgres]
+commands = {[psycopg]commands}
+
+[testenv:pywin34-mssql]
+commands = {[winmssql]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{26,27}-{mysqldb,mysql-oursql},py{34,35}-{mysqlclient,pypostgresql},py{26,27,34,35}-{mysql-connector,pymysql,postgres-psycopg,postgres-pygresql,postgres-pg8000,sqlite},py{27,34,35}-{firebird-fdb,firebirdsql},py{27,34}-flake8,pywin{27,34}-{postgres,mssql}
+envlist = py{26,27}-{mysqldb,mysql-oursql},py{34,35}-{mysqlclient,pypostgresql},py{26,27,34,35}-{mysql-connector,pymysql,postgres-psycopg,postgres-pygresql,postgres-pg8000,sqlite},py{27,34,35}-{firebird-fdb,firebirdsql},py{27,34}-flake8,pywin{27,34}-{postgres-psycopg,mssql}
 
 # Base test environment settings
 [testenv]
@@ -19,12 +19,13 @@ deps =
     mysql-oursql: oursql
     pymysql: pymysql
     postgres-psycopg: psycopg2
+    winpsycopg: psycopg2
     postgres-pygresql: pygresql
     pypostgresql: py-postgresql
     firebird-fdb: fdb
     firebirdsql: firebirdsql
     postgres-pg8000: pg8000
-passenv = CI TRAVIS TRAVIS_*
+passenv = CI TRAVIS TRAVIS_* PGPASSWORD
 # Don't fail or warn on uninstalled commands
 whitelist_externals =
     mysql
@@ -33,7 +34,6 @@ whitelist_externals =
     rm
     sudo
     isql-fb
-    set
 
 # MySQL test environments
 [mysqldb]
@@ -257,20 +257,18 @@ commands =
 
 [winpsycopg]
 commands =
-    set
-    set PGPASSWORD="Password12!"
     -dropdb -w -U postgres sqlobject_test
     createdb -w -U postgres sqlobject_test
-    pytest --cov=sqlobject -D postgres://postgres:@localhost/sqlobject_test?driver=psycopg&charset=utf-8 tests include/tests inheritance/tests versioning/test
+    pytest --cov=sqlobject -D "postgres://postgres:Password12!@localhost/sqlobject_test?driver=psycopg2&charset=utf-8" tests include/tests inheritance/tests versioning/test
     dropdb -w -U postgres sqlobject_test
 
-[testenv:pywin27-postgres]
+[testenv:pywin27-postgres-psycopg]
 commands = {[winpsycopg]commands}
 
 [testenv:pywin27-mssql]
 commands = {[winmssql]commands}
 
-[testenv:pywin34-postgres]
+[testenv:pywin34-postgres-psycopg]
 commands = {[winpsycopg]commands}
 
 [testenv:pywin34-mssql]

--- a/tox.ini
+++ b/tox.ini
@@ -19,12 +19,12 @@ deps =
     mysql-oursql: oursql
     pymysql: pymysql
     postgres-psycopg: psycopg2
-    winpsycopg: psycopg2
     postgres-pygresql: pygresql
     pypostgresql: py-postgresql
     firebird-fdb: fdb
     firebirdsql: firebirdsql
     postgres-pg8000: pg8000
+    mssql: pymssql
 passenv = CI TRAVIS TRAVIS_* PGPASSWORD
 # Don't fail or warn on uninstalled commands
 whitelist_externals =
@@ -34,6 +34,7 @@ whitelist_externals =
     rm
     sudo
     isql-fb
+    sqlcmd
 
 # MySQL test environments
 [mysqldb]
@@ -253,7 +254,10 @@ commands = flake8 .
 # Windows testing
 [winmssql]
 commands =
-   here
+    -sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
+    sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "CREATE DATABASE sqlobject_test"
+    pytest --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql"
+    sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
 
 [winpsycopg]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ whitelist_externals =
     rm
     sudo
     isql-fb
+    set
 
 # MySQL test environments
 [mysqldb]
@@ -254,14 +255,23 @@ commands = flake8 .
 commands =
    here
 
+[winpsycopg]
+commands =
+    set
+    set PGPASSWORD="Password12!"
+    -dropdb -w -U postgres sqlobject_test
+    createdb -w -U postgres sqlobject_test
+    pytest --cov=sqlobject -D postgres://postgres:@localhost/sqlobject_test?driver=psycopg&charset=utf-8 tests include/tests inheritance/tests versioning/test
+    dropdb -w -U postgres sqlobject_test
+
 [testenv:pywin27-postgres]
-commands = {[psycopg]commands}
+commands = {[winpsycopg]commands}
 
 [testenv:pywin27-mssql]
 commands = {[winmssql]commands}
 
 [testenv:pywin34-postgres]
-commands = {[psycopg]commands}
+commands = {[winpsycopg]commands}
 
 [testenv:pywin34-mssql]
 commands = {[winmssql]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     firebirdsql: firebirdsql
     postgres-pg8000: pg8000
     mssql: pymssql
+    mssql: pytest-timeout
 passenv = CI TRAVIS TRAVIS_* PGPASSWORD
 # Don't fail or warn on uninstalled commands
 whitelist_externals =
@@ -256,7 +257,7 @@ commands = flake8 .
 commands =
     -sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "CREATE DATABASE sqlobject_test"
-    pytest --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql" tests
+    pytest -v --timeout=10 --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql"
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
 
 [winpsycopg]

--- a/tox.ini
+++ b/tox.ini
@@ -257,7 +257,8 @@ commands = flake8 .
 commands =
     -sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "CREATE DATABASE sqlobject_test"
-    pytest -v --timeout=30 --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql"
+    pytest --timeout=30 --cov=sqlobject -D "mssql://sa:Password12!@localhost\SQL2014/sqlobject_test?driver=pymssql" tests include/tests inheritance/tests versioning/test
+
     sqlcmd -U sa -P "Password12!" -S .\SQL2014 -Q "DROP DATABASE sqlobject_test"
 
 [winpsycopg]


### PR DESCRIPTION
This adds an appveyor.yml file and tox sections to run the sqlobject test suite on appveyor.com, a windows-based CI service. 

This will require enabling appveyor for the SQLObject project as well.

Currently it only tests postgres and mssql (using pymssql) on a very limited number of configurations, but extending this should be reasonably straightforward.

The MS SQL tests hang in a number of places. I've added pytest-timeout to that test configuration so they at least fail, rather than waiting for apveyor to kill the build (which takes about an hour).  I have no idea why the tests hang.
 
The postgresql test suite has a couple of failures that will need to be resolved.

The ssl test should probably be skipped on appveyor, although I'm not sure how best to indicate it.

I've looked at the test_parse_uri failure, and it's not clear to me whether the test is wrong or whether the code is incorrect, so I haven't touched that.