### PR TITLE
Add Python3 special methods for division to SQLExpression

### DIFF
--- a/sqlobject/sqlbuilder.py
+++ b/sqlobject/sqlbuilder.py
@@ -137,6 +137,18 @@ class SQLExpression:
     def __rdiv__(self, other):
         return SQLOp("/", other, self)
 
+    def __truediv__(self, other):
+        return SQLOp("/", self, other)
+
+    def __rtruediv__(self, other):
+        return SQLOp("/", other, self)
+
+    def __floordiv__(self, other):
+        return SQLConstant("FLOOR")(SQLOp("/", self, other))
+
+    def __rfloordiv__(self, other):
+        return SQLConstant("FLOOR")(SQLOp("/", other, self))
+
     def __pos__(self):
         return SQLPrefix("+", self)
 

--- a/sqlobject/tests/test_sqlbuilder.py
+++ b/sqlobject/tests/test_sqlbuilder.py
@@ -57,6 +57,14 @@ def test_modulo():
         "(((so_test_sql_builder.so_value) % (2)) = (0))"
 
 
+def test_division():
+    SOTestSQLBuilder(name='test', so_value=-11)
+    assert sqlrepr(SOTestSQLBuilder.q.so_value / 4 == -2.75, 'mysql') == \
+        "(((so_test_sql_builder.so_value) / (4)) = (-2.75))"
+    assert sqlrepr(SOTestSQLBuilder.q.so_value // 4 == -3, 'mysql') == \
+        "((FLOOR(((so_test_sql_builder.so_value) / (4)))) = (-3))"
+
+
 def test_str_or_sqlrepr():
     select = Select(['id', 'name'], staticTables=['employees'],
                     where='value>0', orderBy='id')


### PR DESCRIPTION
Adds `__truediv__` and `__floordiv__` (and reciprocals) to better support using SQLExpression objects in Pythonn3.

Note that `__floordiv__` is NOT equivalent to SQL's 'DIV' operator, so the
SQL FLOOR function is used in combination with the / operator.

Should be backwards-compatible with Python2.