### PR TITLE
Bugfix for TypeError using selectBy on a BLOBCol

### DIFF
--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -666,7 +666,6 @@ class DBAPI(DBConnection):
 
     def _SO_columnClause(self, soClass, kw):
         from . import main
-        ops = {None: "IS"}
         data = []
         if 'id' in kw:
             data.append((soClass.sqlmeta.idName, kw.pop('id')))
@@ -694,7 +693,7 @@ class DBAPI(DBConnection):
             return None
         return ' AND '.join(
             ['%s %s %s' %
-             (dbName, ops.get(value, "="), self.sqlrepr(value))
+             (dbName, "IS" if value is None else "=", self.sqlrepr(value))
              for dbName, value
              in data])
 

--- a/sqlobject/tests/test_blob.py
+++ b/sqlobject/tests/test_blob.py
@@ -30,3 +30,6 @@ def test_BLOBCol():
 
     prof2 = ImageData.get(iid)
     assert prof2.image == data
+
+    ImageData(image='string')
+    assert ImageData.selectBy(image='string').count() == 1


### PR DESCRIPTION
When calling someTable.selectBy(someBlobCol="value"), a "TypeError: unhashable type: 'bytearray'" exception is raised.  The cause was that mysqlclient (and possibly other connectors) returns a BLOBCol value as a bytearray, and attempting to look up that value in the ops dict caused the error.