### PR TITLE
Add signals on commit and rollback

### DIFF
--- a/sqlobject/events.py
+++ b/sqlobject/events.py
@@ -211,6 +211,18 @@ class DropTableSignal(Signal):
     after the table has been dropped.
     """
 
+
+class CommitSignal(Signal):
+    """
+    Called on transaction commit
+    """
+
+class RollbackSignal(Signal):
+    """
+    Called on transaction rollback
+    """
+
+
 ############################################################
 # Event Debugging
 ############################################################


### PR DESCRIPTION
My organization uses an old fork of this project and we found the need for this modification.

We were publishing internal data to microservices using the existing signals for row update/destroy. We found that we were sometimes publishing data that was in the middle of a transaction block and being rolled back, causing bad data to be published. We decided to buffer it internally and only release it once we receive a commit signal, verified against class names/ids, or just flush the buffer on a rollback.

I thought I would share the work in case anyone else found a need for it.