### PR TITLE
Exclude sqlmeta members from some of the api docs

### DIFF
--- a/docs/api/sqlobject.include.tests.test_hashcol.rst
+++ b/docs/api/sqlobject.include.tests.test_hashcol.rst
@@ -5,3 +5,4 @@ sqlobject\.include\.tests\.test\_hashcol module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.inheritance.tests.test_aggregates.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_aggregates.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_aggregates module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.inheritance.tests.test_asdict.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_asdict.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_asdict module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.inheritance.tests.test_deep_inheritance.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_deep_inheritance.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_deep\_inheritance module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.inheritance.tests.test_destroy_cascade.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_destroy_cascade.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_destroy\_cascade module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.inheritance.tests.test_foreignKey.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_foreignKey.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_foreignKey module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.inheritance.tests.test_indexes.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_indexes.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_indexes module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,indexDefinitions

--- a/docs/api/sqlobject.inheritance.tests.test_inheritance.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_inheritance.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_inheritance module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.inheritance.tests.test_inheritance_tree.rst
+++ b/docs/api/sqlobject.inheritance.tests.test_inheritance_tree.rst
@@ -5,3 +5,4 @@ sqlobject\.inheritance\.tests\.test\_inheritance\_tree module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.manager.command.rst
+++ b/docs/api/sqlobject.manager.command.rst
@@ -5,3 +5,4 @@ sqlobject\.manager\.command module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_ForeignKey.rst
+++ b/docs/api/sqlobject.tests.test_ForeignKey.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_ForeignKey module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_NoneValuedResultItem.rst
+++ b/docs/api/sqlobject.tests.test_NoneValuedResultItem.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_NoneValuedResultItem module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_SQLMultipleJoin.rst
+++ b/docs/api/sqlobject.tests.test_SQLMultipleJoin.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_SQLMultipleJoin module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_SQLRelatedJoin.rst
+++ b/docs/api/sqlobject.tests.test_SQLRelatedJoin.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_SQLRelatedJoin module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_SingleJoin.rst
+++ b/docs/api/sqlobject.tests.test_SingleJoin.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_SingleJoin module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_aggregates.rst
+++ b/docs/api/sqlobject.tests.test_aggregates.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_aggregates module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_aliases.rst
+++ b/docs/api/sqlobject.tests.test_aliases.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_aliases module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_asdict.rst
+++ b/docs/api/sqlobject.tests.test_asdict.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_asdict module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_auto.rst
+++ b/docs/api/sqlobject.tests.test_auto.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_auto module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_basic.rst
+++ b/docs/api/sqlobject.tests.test_basic.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_basic module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_blob.rst
+++ b/docs/api/sqlobject.tests.test_blob.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_blob module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_cache.rst
+++ b/docs/api/sqlobject.tests.test_cache.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_cache module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_class_hash.rst
+++ b/docs/api/sqlobject.tests.test_class_hash.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_class\_hash module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_columns_order.rst
+++ b/docs/api/sqlobject.tests.test_columns_order.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_columns\_order module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_combining_joins.rst
+++ b/docs/api/sqlobject.tests.test_combining_joins.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_combining\_joins module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_complex_sorting.rst
+++ b/docs/api/sqlobject.tests.test_complex_sorting.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_complex\_sorting module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_create_drop.rst
+++ b/docs/api/sqlobject.tests.test_create_drop.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_create\_drop module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_csvexport.rst
+++ b/docs/api/sqlobject.tests.test_csvexport.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_csvexport module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_cyclic_reference.rst
+++ b/docs/api/sqlobject.tests.test_cyclic_reference.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_cyclic\_reference module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_datetime.rst
+++ b/docs/api/sqlobject.tests.test_datetime.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_datetime module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_decimal.rst
+++ b/docs/api/sqlobject.tests.test_decimal.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_decimal module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_delete.rst
+++ b/docs/api/sqlobject.tests.test_delete.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_delete module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_distinct.rst
+++ b/docs/api/sqlobject.tests.test_distinct.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_distinct module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_enum.rst
+++ b/docs/api/sqlobject.tests.test_enum.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_enum module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_events.rst
+++ b/docs/api/sqlobject.tests.test_events.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_events module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_exceptions.rst
+++ b/docs/api/sqlobject.tests.test_exceptions.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_exceptions module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_expire.rst
+++ b/docs/api/sqlobject.tests.test_expire.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_expire module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_groupBy.rst
+++ b/docs/api/sqlobject.tests.test_groupBy.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_groupBy module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_identity.rst
+++ b/docs/api/sqlobject.tests.test_identity.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_identity module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_indexes.rst
+++ b/docs/api/sqlobject.tests.test_indexes.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_indexes module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns,indexDefinitions

--- a/docs/api/sqlobject.tests.test_inheritance.rst
+++ b/docs/api/sqlobject.tests.test_inheritance.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_inheritance module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_joins.rst
+++ b/docs/api/sqlobject.tests.test_joins.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_joins module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_joins_conditional.rst
+++ b/docs/api/sqlobject.tests.test_joins_conditional.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_joins\_conditional module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_jsonbcol.rst
+++ b/docs/api/sqlobject.tests.test_jsonbcol.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_jsonbcol module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_jsoncol.rst
+++ b/docs/api/sqlobject.tests.test_jsoncol.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_jsoncol module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_lazy.rst
+++ b/docs/api/sqlobject.tests.test_lazy.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_lazy module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_new_joins.rst
+++ b/docs/api/sqlobject.tests.test_new_joins.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_new\_joins module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_paste.rst
+++ b/docs/api/sqlobject.tests.test_paste.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_paste module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_perConnection.rst
+++ b/docs/api/sqlobject.tests.test_perConnection.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_perConnection module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_pickle.rst
+++ b/docs/api/sqlobject.tests.test_pickle.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_pickle module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_picklecol.rst
+++ b/docs/api/sqlobject.tests.test_picklecol.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_picklecol module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_postgres.rst
+++ b/docs/api/sqlobject.tests.test_postgres.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_postgres module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_reparent_sqlmeta.rst
+++ b/docs/api/sqlobject.tests.test_reparent_sqlmeta.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_reparent\_sqlmeta module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_schema.rst
+++ b/docs/api/sqlobject.tests.test_schema.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_schema module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_select.rst
+++ b/docs/api/sqlobject.tests.test_select.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_select module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_select_through.rst
+++ b/docs/api/sqlobject.tests.test_select_through.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_select\_through module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_setters.rst
+++ b/docs/api/sqlobject.tests.test_setters.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_setters module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_slice.rst
+++ b/docs/api/sqlobject.tests.test_slice.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_slice module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_sorting.rst
+++ b/docs/api/sqlobject.tests.test_sorting.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_sorting module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_sqlbuilder.rst
+++ b/docs/api/sqlobject.tests.test_sqlbuilder.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_sqlbuilder module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_sqlbuilder_dbspecific.rst
+++ b/docs/api/sqlobject.tests.test_sqlbuilder_dbspecific.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_sqlbuilder\_dbspecific module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_sqlbuilder_joins_instances.rst
+++ b/docs/api/sqlobject.tests.test_sqlbuilder_joins_instances.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_sqlbuilder\_joins\_instances module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_sqlite.rst
+++ b/docs/api/sqlobject.tests.test_sqlite.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_sqlite module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_sqlobject_admin.rst
+++ b/docs/api/sqlobject.tests.test_sqlobject_admin.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_sqlobject\_admin module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_string_id.rst
+++ b/docs/api/sqlobject.tests.test_string_id.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_string\_id module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_style.rst
+++ b/docs/api/sqlobject.tests.test_style.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_style module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_subqueries.rst
+++ b/docs/api/sqlobject.tests.test_subqueries.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_subqueries module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_transactions.rst
+++ b/docs/api/sqlobject.tests.test_transactions.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_transactions module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_unicode.rst
+++ b/docs/api/sqlobject.tests.test_unicode.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_unicode module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_uuidcol.rst
+++ b/docs/api/sqlobject.tests.test_uuidcol.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_uuidcol module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_validation.rst
+++ b/docs/api/sqlobject.tests.test_validation.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_validation module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.tests.test_views.rst
+++ b/docs/api/sqlobject.tests.test_views.rst
@@ -5,3 +5,4 @@ sqlobject\.tests\.test\_views module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns

--- a/docs/api/sqlobject.versioning.test.test_version.rst
+++ b/docs/api/sqlobject.versioning.test.test_version.rst
@@ -5,3 +5,4 @@ sqlobject\.versioning\.test\.test\_version module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: columnDefinitions,columnList,columns


### PR DESCRIPTION
The inclusion of of these sqlmeta members in these files breaks reproducible builds as sphinx includes the memory addresses when building the documentation.

Since the contents aren't particularly useful, the simplest fix is to simply exclude them from the documentation build.

For an example of the reproducibility issues, see https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/sqlobject.html