### PR TITLE
Use augmented assignment statements

### DIFF
--- a/sqlobject/col.py
+++ b/sqlobject/col.py
@@ -733,9 +733,9 @@ class SOIntCol(SOCol):
         if self.length and self.length >= 1:
             _ret = "%s(%d)" % (_ret, self.length)
         if self.unsigned:
-            _ret = _ret + " UNSIGNED"
+            _ret += " UNSIGNED"
         if self.zerofill:
-            _ret = _ret + " ZEROFILL"
+            _ret += " ZEROFILL"
         return _ret
 
     def _sqlType(self):
@@ -1092,9 +1092,8 @@ class SOForeignKey(SOKeyCol):
         sql = ' '.join([fidName, self._maxdbType()])
         tName = other.sqlmeta.table
         idName = self.refColumn or other.sqlmeta.idName
-        sql = sql + ',' + '\n'
-        sql = sql + 'FOREIGN KEY (%s) REFERENCES %s(%s)' % (fidName, tName,
-                                                            idName)
+        sql += ',\nFOREIGN KEY (%s) REFERENCES %s(%s)' % (fidName, tName,
+                                                          idName)
         return sql
 
     def maxdbCreateReferenceConstraint(self):

--- a/sqlobject/dbconnection.py
+++ b/sqlobject/dbconnection.py
@@ -108,8 +108,8 @@ class DBConnection:
         auth = getattr(self, 'user', '') or ''
         if auth:
             if self.password:
-                auth = auth + ':' + self.password
-            auth = auth + '@'
+                auth += ':' + self.password
+            auth += '@'
         else:
             assert not getattr(self, 'password', None), (
                 'URIs cannot express passwords without usernames')
@@ -129,8 +129,8 @@ class DBConnection:
         if auth:
             auth = quote(auth)
             if self.password:
-                auth = auth + ':' + quote(self.password)
-            auth = auth + '@'
+                auth += ':' + quote(self.password)
+            auth += '@'
         else:
             assert not getattr(self, 'password', None), (
                 'URIs cannot express passwords without usernames')

--- a/sqlobject/joins.py
+++ b/sqlobject/joins.py
@@ -170,9 +170,9 @@ class SOMultipleJoin(SOJoin):
         if not self.joinMethodName:
             name = self.otherClassName[0].lower() + self.otherClassName[1:]
             if name.endswith('s'):
-                name = name + "es"
+                name += "es"
             else:
-                name = name + "s"
+                name += "s"
             self.joinMethodName = name
         if addRemoveName:
             self.addRemoveName = addRemoveName

--- a/sqlobject/tests/test_select.py
+++ b/sqlobject/tests/test_select.py
@@ -66,7 +66,7 @@ def test_04_indexed_ended_by_exception():
     try:
         while 1:
             all[count]
-            count = count + 1
+            count += 1
             # Stop the test if it's gone on too long
             if count > len(names):
                 break


### PR DESCRIPTION
Source code like “`var = var + `…” was specified at some places so far.
Please [use augmented assignment statements](https://docs.python.org/3/reference/simple_stmts.html#augmented-assignment-statements "Description for augmented assignment statements") instead because they are succinct and can be more efficient.

Fix #148.