### PR TITLE
Convert five statements to augmented assignments

### DIFF
--- a/sqlobject/cache.py
+++ b/sqlobject/cache.py
@@ -96,7 +96,7 @@ class CacheFactory(object):
                 self.cullCount = 0
                 self.cull()
             else:
-                self.cullCount = self.cullCount + 1
+                self.cullCount += 1
 
             try:
                 return self.cache[id]
@@ -174,7 +174,7 @@ class CacheFactory(object):
                 self.cullCount = 0
                 self.cull()
             else:
-                self.cullCount = self.cullCount + 1
+                self.cullCount += 1
             self.cache[id] = obj
         else:
             self.expiredCache[id] = ref(obj)

--- a/sqlobject/maxdb/maxdbconnection.py
+++ b/sqlobject/maxdb/maxdbconnection.py
@@ -147,10 +147,7 @@ class MaxdbConnection(DBAPI):
     def sqlAddLimit(cls, query, limit):
         sql = query
         sql = sql.replace("SELECT", "SELECT ROWNO, ")
-        if sql.find('WHERE') != -1:
-            sql = sql + ' AND ' + limit
-        else:
-            sql = sql + 'WHERE ' + limit
+        sql += ('WHERE ' if sql.find('WHERE') == -1 else ' AND ') + limit
         return sql
 
     @classmethod


### PR DESCRIPTION
Source code like “`var = var + `…” was specified at some places so far.
Please [use augmented assignment statements](https://docs.python.org/3/reference/simple_stmts.html#augmented-assignment-statements "Description for augmented assignment statements") instead because they are succinct and can be more efficient.