### PR TITLE
Remove "U" option in open for Python 3.11 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info[:2] == (2, 7):
     execfile(versionpath, sqlobject_version)  # noqa: F821 'execfile' Py3
 
 elif sys.version_info >= (3, 4):
-    exec(open(versionpath, 'rU').read(), sqlobject_version)
+    exec(open(versionpath, 'r').read(), sqlobject_version)
 
 else:
     raise ImportError("SQLObject requires Python 2.7 or 3.4+")


### PR DESCRIPTION
> `open()`, `io.open()`, `codecs.open()` and `fileinput.FileInput` no longer accept `'U'` (“universal newline”) in the file mode. This flag was deprecated since Python 3.3. In Python 3, the “universal newline” is used by default when a file is open in text mode. The newline parameter of `open()` controls how universal newlines works. (Contributed by Victor Stinner in bpo-37330.)

https://bugs.python.org/issue37330
https://docs.python.org/3.11/whatsnew/3.11.html
