### PR TITLE
fix: connect to old mssql versions via set tds_version uri parameter

### DIFF
--- a/sqlobject/mssql/mssqlconnection.py
+++ b/sqlobject/mssql/mssqlconnection.py
@@ -105,6 +105,8 @@ class MSSQLConnection(DBAPI):
                     ('host', keys.host),
                     ('port', keys.port),
                     ('timeout', keys.timeout),
+                    ('charset', keys.charset),
+                    ('tds_version', keys.tds_version),
                 ):
                     if value:
                         keys_dict[attr] = value
@@ -118,6 +120,8 @@ class MSSQLConnection(DBAPI):
         self.host = host
         self.port = port
         self.db = db
+        self.charset = kw.pop("charset", None)
+        self.tds_version = kw.pop("tds_version", None)
         self._server_version = None
         self._can_use_max_types = None
         self._can_use_microseconds = None


### PR DESCRIPTION
This pull contains small change of MSSQLConnection class adding charset and tds_version properties enabling to connect to older mssql server versions by setting tds_version parameter in the URI.

Just had to connect to older version.
It was possible to connect using pymssql-2.2.7, but this is rather old versions and there are no wheels for fresh python.
So this small change makes it possible to connect just by adding setting uri like:
```
mssql://user:pass@server:port/database?driver=pymssql&charset=UTF-8&tds_version=7.0
```
with latest python and pymssql.

Have no ifrastucture to test all drivers...